### PR TITLE
feat(image): default drama assets to Evolink gpt-image-2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ bash packaging/setup.sh        # interactive wizard, writes ~/.config/videoclaw/
 Until videoclaw is on PyPI, install from a wheel URL:
 
 ```bash
-uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.2/videoclaw-0.1.2-py3-none-any.whl videoclaw setup
+uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.3/videoclaw-0.1.3-py3-none-any.whl videoclaw setup
 ```
 
 Or from local source (works today):
@@ -125,7 +125,7 @@ claw --json doctor
 ```bash
 # 1. Install (one-time)
 uvx --from <wheel-url> videoclaw setup
-# → installs videoclaw-* skills as videoclaw-workflow-0.1.2/, etc.
+# → installs videoclaw-* skills as videoclaw-workflow-0.1.3/, etc.
 #   into ~/.openclaw-autoclaw/skills/ (versioned naming convention)
 
 # 2. Verify
@@ -218,6 +218,9 @@ Any agent with a Bash tool can also call `claw` directly — see the
 ### CLI + Bash tool (universal)
 
 ```bash
+claw image "character turnaround sheet" \
+  --provider evolink --model gpt-image-2 \
+  --resolution 1K --quality medium
 claw drama new "<synopsis>" --title "<title>" --lang zh
 claw drama plan <series_id>
 claw drama design-characters <series_id>
@@ -225,6 +228,16 @@ claw drama design-scenes <series_id>
 claw drama run <series_id> --max-shots 3
 claw drama audit <series_id>
 claw drama export <series_id>
+```
+
+Image assets default to Evolink `gpt-image-2` at `resolution=1K` and
+`quality=medium`. Agents should use that for character turnaround sheets,
+scene/location references, props, cover frames, and direct `claw image`
+calls unless the user explicitly chooses another provider. BytePlus
+`seedream-5.0-lite` remains available as an explicit image fallback:
+
+```bash
+claw image "scene reference" --provider byteplus --model seedream-5.0-lite
 ```
 
 Every command supports `--json` for predictable parsing. Exit codes:
@@ -238,8 +251,9 @@ Every command supports `--json` for predictable parsing. Exit codes:
 | 4 | Blocked | read envelope `error` field |
 
 `claw doctor` returns 3 specifically when `VIDEOCLAW_EVOLINK_API_KEY`
-is missing — coding agents can branch on `$? == 3` to auto-trigger
-configuration.
+is missing. That key powers both the LLM gateway and default Evolink
+`gpt-image-2` image assets, so coding agents can branch on `$? == 3`
+to auto-trigger configuration.
 
 ### MCP shim (optional, secondary)
 
@@ -337,7 +351,7 @@ exit_codes (0-4), distribution channels, health_check.
 
 ```bash
 python packaging/skills-validate.py skills/
-# VALID: 5 skill(s) under skills conform (version 0.1.2)
+# VALID: 5 skill(s) under skills conform (version 0.1.3)
 ```
 
 ## Write-scope (M002 + M003)

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ VideoClaw gives your coding agent the **CLI commands and skills** to plan, desig
 
 ## Get Started
 
-**Prerequisites:** Python ≥ 3.12, [uv](https://docs.astral.sh/uv/getting-started/installation/), an Evolink LLM key, and (for real video) an ARK / Seedance key.
+**Prerequisites:** Python ≥ 3.12, [uv](https://docs.astral.sh/uv/getting-started/installation/), an Evolink key for LLM + default `gpt-image-2` image assets, and (for real video) an ARK / Seedance key.
 
 ### 1. Install the CLI + skills
 
 ```bash
-uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.2/videoclaw-0.1.2-py3-none-any.whl videoclaw setup
+uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.3/videoclaw-0.1.3-py3-none-any.whl videoclaw setup
 ```
 
 `claw setup` detects which coding agents are present and copies the
@@ -54,7 +54,7 @@ Use `claw setup --no-npx` to force the fallback explicitly, or
 - **From source (Python ≥ 3.12)** — `git clone … && uv sync && uv run claw --help`
 - **One-line installer (post-release)** — `curl -fsSL https://raw.githubusercontent.com/AIGC-Hackers/videoclaw-cli/main/install.sh | sh`
 - **Docker** — `docker build -t videoclaw-cli -f packaging/Dockerfile . && docker run --rm videoclaw-cli version`
-- **Wheel from GitHub Releases** — `pip install https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.2/videoclaw-0.1.2-py3-none-any.whl`
+- **Wheel from GitHub Releases** — `pip install https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.3/videoclaw-0.1.3-py3-none-any.whl`
 
 Full channel matrix: [`packaging/DISTRIBUTION-PLAN.md`](packaging/DISTRIBUTION-PLAN.md).
 
@@ -93,7 +93,7 @@ In a Claude Code conversation, say *"use videoclaw to make a drama"* — the `vi
 <summary><b>OpenClaw</b> — versioned skill names</summary>
 
 ```bash
-uvx --from <wheel-url> videoclaw setup    # → ~/.openclaw-autoclaw/skills/videoclaw-workflow-0.1.2/
+uvx --from <wheel-url> videoclaw setup    # → ~/.openclaw-autoclaw/skills/videoclaw-workflow-0.1.3/
 claw --json doctor
 ```
 Reference skills as `/videoclaw-workflow` in your orchestration prompts.
@@ -160,6 +160,7 @@ claw drama run <series_id> --max-shots 3                # generate first 3 shots
 | `claw version` | Print the version string. |
 | `claw --json doctor` | Health check (envelope + exit code). |
 | `claw --json info` | Registered models / drama series count. |
+| `claw image "<prompt>"` | Generate an image asset (defaults to Evolink `gpt-image-2`, `1K`, `medium`). |
 | `claw drama new "<synopsis>"` | Create a new series from a synopsis (LLM authors script). |
 | `claw drama import <script>` | Import a locked external script. |
 | `claw drama plan <id>` | Plan episode shots via LLM. |
@@ -179,6 +180,7 @@ claw setup [--dry-run] [--uninstall] [--copy] [--no-npx] [--agent <name>]
 claw version
 claw doctor [--json]
 claw info [--json]
+claw image <prompt> [--provider evolink] [--model gpt-image-2] [--resolution 1K] [--quality medium]
 claw generate <prompt>            # single-shot full pipeline
 claw stage-* …                    # 7 staged-pipeline commands
 
@@ -301,10 +303,13 @@ Run `bash packaging/setup.sh` (interactive wizard) — writes
 
 | Variable | Required | Description |
 |---|---|---|
-| `VIDEOCLAW_EVOLINK_API_KEY` | Yes | Evolink LLM gateway (Claude / GPT / Kimi / DeepSeek). |
+| `VIDEOCLAW_EVOLINK_API_KEY` | Yes | Evolink LLM gateway (Claude / GPT / Kimi / DeepSeek) and default `gpt-image-2` image assets. |
 | `VIDEOCLAW_ARK_API_KEY` | For Seedance | Seedance 2.0 video API. |
 | `VIDEOCLAW_DEFAULT_LLM` | No | Default LLM (default `claude-sonnet-4-6`). |
 | `VIDEOCLAW_DEFAULT_VIDEO_MODEL` | No | Default video model (default `seedance-2.0`; use `mock` for dry-run). |
+| `VIDEOCLAW_DEFAULT_IMAGE_PROVIDER` | No | Default image provider (default `evolink`; optional fallback `byteplus`). |
+| `VIDEOCLAW_DEFAULT_IMAGE_MODEL` | No | Default image model (default `gpt-image-2`; BytePlus fallback `seedream-5.0-lite`). |
+| `VIDEOCLAW_DEFAULT_IMAGE_RESOLUTION` / `VIDEOCLAW_DEFAULT_IMAGE_QUALITY` | No | Evolink image defaults (`1K` / `medium`). |
 | `VIDEOCLAW_PROJECTS_DIR` | No | Project storage path (default `./projects`). |
 | `VIDEOCLAW_BUDGET_DEFAULT_USD` | No | Budget cap (default `10.0`). |
 | `VIDEOCLAW_KLING_*` / `VIDEOCLAW_MINIMAX_API_KEY` / `VIDEOCLAW_BYTEPLUS_*` | Optional | Alternative video adapters. |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,39 @@ All notable changes to videoclaw are documented in this file. Format
 follows the google/agents-cli style — `## [<version>] - YYYY-MM-DD`
 with grouped bullets.
 
+## [0.1.3] - 2026-05-08
+
+Makes Evolink `gpt-image-2` the default image asset generator for coding-agent
+drama workflows and packaged CLI use.
+
+### Behavior
+
+- Image defaults now prefer Evolink `gpt-image-2` with `resolution=1K` and
+  `quality=medium`.
+- Character, scene, prop, and cover asset generation use a shared provider
+  resolver that tries `gpt-image-2` first unless a provider is explicitly
+  configured.
+- BytePlus `seedream-5.0-lite` remains available as an explicit or configured
+  fallback, but no longer outranks Evolink image generation.
+- `claw image` defaults to the configured image provider and exposes
+  `--model`, `--resolution`, and `--quality`.
+- `claw drama design-characters`, `design-scenes`, and `design-cover` now
+  accept `--image-provider` and `--image-model` overrides.
+
+### Agent CLI
+
+- Skills and top-level docs now tell coding agents to use Evolink
+  `gpt-image-2` for character sheets, location references, props, cover frames,
+  and direct image smoke tests.
+- Release metadata, install script defaults, manifest version, and skill
+  metadata are aligned to `0.1.3`.
+
+### Tests
+
+- Added unit coverage for Evolink `gpt-image-2` payload defaults, async task
+  polling, `image_urls` passthrough, provider fallback ordering, direct
+  `claw image` defaults, and drama design image override flags.
+
 ## [0.1.2] - 2026-05-07
 
 Stabilizes the packaged Codex / coding-agent drama workflow with Sonnet

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@
 # Overrides via env::
 #
 #   GH_OWNER=AIGC-Hackers GH_REPO=videoclaw-cli   # source release
-#   VERSION=0.1.2                                 # which release tag
+#   VERSION=0.1.3                                 # which release tag
 #   INSTALL_DIR=$HOME/.local/bin                  # where to drop the binary
 #   CHANNEL=auto|uv|binary                        # force channel selection
 
@@ -27,7 +27,7 @@ set -eu
 
 GH_OWNER=${GH_OWNER:-AIGC-Hackers}
 GH_REPO=${GH_REPO:-videoclaw-cli}
-VERSION=${VERSION:-0.1.2}
+VERSION=${VERSION:-0.1.3}
 INSTALL_DIR=${INSTALL_DIR:-${HOME}/.local/bin}
 CHANNEL=${CHANNEL:-auto}
 

--- a/packaging/agent-cli.yaml
+++ b/packaging/agent-cli.yaml
@@ -14,7 +14,7 @@ schema: agent-cli/v1
 # --- Identity ---
 name: videoclaw
 binary: claw
-version: "0.1.2"
+version: "0.1.3"
 description: |
   Agent OS for AI video generation — TikTok-format Western live-action drama
   pipeline (drama plan → design → generate → audit → export).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "videoclaw"
-version = "0.1.2"
+version = "0.1.3"
 description = "The Agent OS for AI Video Generation"
 readme = "README.md"
 license = { text = "Modified-MIT" }
@@ -28,6 +28,8 @@ dependencies = [
     "aiosqlite>=0.20.0",
     "zhipuai>=2.1.0",
     "edge-tts>=7.0.0",
+    "numpy>=2.0.0",
+    "pillow>=12.0.0",
 ]
 
 [project.optional-dependencies]

--- a/skills/videoclaw-checkpoint/SKILL.md
+++ b/skills/videoclaw-checkpoint/SKILL.md
@@ -12,11 +12,11 @@ description: >
 metadata:
   author: VideoClaw Contributors
   license: Modified-MIT
-  version: 0.1.2
+  version: 0.1.3
   requires:
     bins:
       - claw
-    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.0/videoclaw-0.1.0-py3-none-any.whl videoclaw setup"
+    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.3/videoclaw-0.1.3-py3-none-any.whl videoclaw setup"
 ---
 
 # Checkpoint Recovery

--- a/skills/videoclaw-drama-setup/SKILL.md
+++ b/skills/videoclaw-drama-setup/SKILL.md
@@ -13,11 +13,11 @@ description: >
 metadata:
   author: VideoClaw Contributors
   license: Modified-MIT
-  version: 0.1.2
+  version: 0.1.3
   requires:
     bins:
       - claw
-    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.0/videoclaw-0.1.0-py3-none-any.whl videoclaw setup"
+    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.3/videoclaw-0.1.3-py3-none-any.whl videoclaw setup"
 ---
 
 # Drama Series Setup

--- a/skills/videoclaw-models/SKILL.md
+++ b/skills/videoclaw-models/SKILL.md
@@ -6,19 +6,20 @@ description: >
   mock", "切视频模型", or invokes `claw model list` / `claw model pull`.
   Also load before `claw drama run` so the agent picks the adapter that
   matches the user's quality / cost / region constraints. Covers the
-  registered adapters, the Seedance HTTPS-URL constraint, and the
-  "stylized faces only" Privacy Information rule.
+  registered adapters, Evolink gpt-image-2 image defaults, BytePlus
+  seedream-5.0-lite image fallback, the Seedance HTTPS-URL constraint,
+  and the "stylized faces only" Privacy Information rule.
 metadata:
   author: VideoClaw Contributors
   license: Modified-MIT
-  version: 0.1.2
+  version: 0.1.3
   requires:
     bins:
       - claw
-    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.0/videoclaw-0.1.0-py3-none-any.whl videoclaw setup"
+    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.3/videoclaw-0.1.3-py3-none-any.whl videoclaw setup"
 ---
 
-# Video Adapter Selection
+# Video And Image Adapter Selection
 
 > **STOP — check `claw model list` first.** The set of healthy
 > adapters depends on which API keys are configured. Selecting an
@@ -90,6 +91,24 @@ Map of adapter → key (see `claw doctor --json` for status):
 LLM keys (for script writing, audit) live in
 `VIDEOCLAW_EVOLINK_API_KEY` and route to Claude / GPT / Kimi /
 DeepSeek through one gateway.
+
+## Image asset defaults
+
+Image assets default to Evolink `gpt-image-2` with `resolution=1K`
+and `quality=medium`. Use this for character turnaround sheets,
+scene/location references, props, cover frames, and direct one-off
+images:
+
+```bash
+claw image "character turnaround sheet" \
+  --provider evolink --model gpt-image-2 --size 3:4 \
+  --resolution 1K --quality medium
+```
+
+BytePlus remains an optional fallback for image generation. When the
+user explicitly asks for BytePlus image assets, prefer
+`--provider byteplus --model seedream-5.0-lite`. Do not confuse
+`seedream-5.0-lite` (image) with `seedance-*` (video).
 
 ## Hard constraints (read these before designing assets)
 

--- a/skills/videoclaw-troubleshoot/SKILL.md
+++ b/skills/videoclaw-troubleshoot/SKILL.md
@@ -5,18 +5,19 @@ description: >
   non-zero, the user reports an error, "claw 报错", "为什么生成失败",
   or one of these specific symptoms: Seedance privacy-information
   rejection on realistic faces, base64 data-URI rejected by Seedance
-  proxy, EdgeTTS voice_id mismatch, Evolink rate limiting, missing API
-  key, doctor returns 3, install.sh reports unsupported OS. Also use
-  to interpret videoclaw's exit-code contract
+  proxy, EdgeTTS voice_id mismatch, Evolink gpt-image-2 auth/quota or
+  model-access failure, Evolink rate limiting, missing API key, doctor
+  returns 3, install.sh reports unsupported OS. Also use to interpret
+  videoclaw's exit-code contract
   (0 ok / 1 runtime / 2 usage / 3 auth / 4 blocked).
 metadata:
   author: VideoClaw Contributors
   license: Modified-MIT
-  version: 0.1.2
+  version: 0.1.3
   requires:
     bins:
       - claw
-    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.0/videoclaw-0.1.0-py3-none-any.whl videoclaw setup"
+    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.3/videoclaw-0.1.3-py3-none-any.whl videoclaw setup"
 ---
 
 # Troubleshooting & Doctor
@@ -63,7 +64,8 @@ claw --json doctor
 
 The envelope's `data` field includes per-key health for:
 
-- `VIDEOCLAW_EVOLINK_API_KEY` — LLM gateway (required)
+- `VIDEOCLAW_EVOLINK_API_KEY` — LLM gateway and default
+  `gpt-image-2` image assets (required)
 - `VIDEOCLAW_ARK_API_KEY` — Seedance video (required for real video)
 - `VIDEOCLAW_KLING_*` / `VIDEOCLAW_MINIMAX_API_KEY` /
   `VIDEOCLAW_BYTEPLUS_*` / `VIDEOCLAW_ZHIPU_API_KEY` /
@@ -139,16 +141,48 @@ claw --json doctor             # should now exit 0
 
 ### `429 Too Many Requests` — Evolink rate limit
 
-**Symptom**: `drama plan` / `drama script` returns 1 with stderr
-mentioning rate limit on the LLM gateway.
+**Symptom**: `drama plan`, `drama script`, `drama design-*`, or
+`claw image` returns 1 with stderr mentioning rate limit on the
+Evolink gateway.
 
-**Fix**: Wait ~60s and retry. If persistent:
+**Fix**: Wait ~60s and retry. If persistent for LLM planning:
 
 ```bash
 # Override default model to something less rate-limited
 export VIDEOCLAW_DEFAULT_LLM=claude-sonnet-4-6  # stronger structured output
 claw drama plan <series_id>
 ```
+
+If the rate limit is specifically for image assets, keep Evolink
+`gpt-image-2` as the preferred default and use BytePlus
+`seedream-5.0-lite` only as an explicit fallback:
+
+```bash
+claw image "scene reference" --provider byteplus --model seedream-5.0-lite
+```
+
+### Evolink `gpt-image-2` auth / quota / model-access failure
+
+**Symptom**: `claw image` or `drama design-characters` /
+`design-scenes` / `design-cover` fails with 401, 403, quota exceeded,
+or a message that `gpt-image-2` is unavailable.
+
+**Cause**: Image assets default to Evolink `gpt-image-2`
+(`resolution=1K`, `quality=medium`) and require a valid
+`VIDEOCLAW_EVOLINK_API_KEY` with image-generation access.
+
+**Fix**:
+
+```bash
+claw --json doctor
+export VIDEOCLAW_EVOLINK_API_KEY=sk-...
+claw image "smoke test" --provider evolink --model gpt-image-2 \
+  --resolution 1K --quality medium
+```
+
+If the key is valid but the account lacks `gpt-image-2` access, ask
+the provider to enable it or temporarily use explicit BytePlus image
+fallback: `--provider byteplus --model seedream-5.0-lite`.
 
 ### EdgeTTS voice fallback warning
 

--- a/skills/videoclaw-workflow/SKILL.md
+++ b/skills/videoclaw-workflow/SKILL.md
@@ -15,11 +15,11 @@ description: >
 metadata:
   author: VideoClaw Contributors
   license: Modified-MIT
-  version: 0.1.2
+  version: 0.1.3
   requires:
     bins:
       - claw
-    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.0/videoclaw-0.1.0-py3-none-any.whl videoclaw setup"
+    install: "uvx --from https://github.com/AIGC-Hackers/videoclaw-cli/releases/download/v0.1.3/videoclaw-0.1.3-py3-none-any.whl videoclaw setup"
 ---
 
 # VideoClaw Drama Production Workflow
@@ -36,7 +36,8 @@ output a 50–90s episode through the
 **setup → plan → design → preview → generate → audit → export**
 lifecycle.
 
-> Requires: videoclaw ≥ 0.1.0 with Evolink LLM key configured. Run
+> Requires: videoclaw ≥ 0.1.0 with Evolink key configured for LLM and
+> default `gpt-image-2` image assets. Run
 > `claw --json doctor` first; if it returns exit 3, load
 > `/videoclaw-troubleshoot` to fix the auth path.
 
@@ -55,7 +56,10 @@ these and **wait for answers** — do not assume:
    genres (`thriller`, `romance`, `comedy`) acceptable.
 5. **Video model preference?** — default `seedance-2.0`. If the user
    has cost / region constraints, load `/videoclaw-models`.
-6. **Any constraints on faces?** — Seedance Privacy Information filter
+6. **Image asset provider?** — default Evolink `gpt-image-2`
+   (`1K`, `medium`). BytePlus `seedream-5.0-lite` is an optional
+   explicit fallback, not the default.
+7. **Any constraints on faces?** — Seedance Privacy Information filter
    rejects realistic women's faces; turnarounds must be stylized.
 
 Once answered, persist intent in a working note (e.g. project memo)
@@ -95,6 +99,25 @@ claw drama design-characters <series_id>     # Universal Reference turnaround sh
 claw drama design-scenes <series_id>         # location reference images
 claw drama design-cover <series_id> --episode 1  # TikTok thumbnail
 claw drama assign-voices <series_id>         # TTS voice profile per character
+```
+
+Default image asset generation uses Evolink `gpt-image-2` at
+`resolution=1K` and `quality=medium` for character turnaround sheets,
+scene/location references, props, and cover frames. For direct image
+checks, use:
+
+```bash
+claw image "location reference, cinematic motel exterior" \
+  --provider evolink --model gpt-image-2 --size 16:9 \
+  --resolution 1K --quality medium
+```
+
+Only use BytePlus as an explicit fallback when requested or when
+Evolink image access is unavailable:
+
+```bash
+claw image "character turnaround sheet" \
+  --provider byteplus --model seedream-5.0-lite --size 3:4
 ```
 
 If reference image URLs become stale (Seedance refuses base64; uses

--- a/src/videoclaw/__init__.py
+++ b/src/videoclaw/__init__.py
@@ -15,7 +15,7 @@ server : REST API server.
 cli : Command-line interface.
 """
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 __all__ = [
     "__version__",

--- a/src/videoclaw/cli/drama/_design.py
+++ b/src/videoclaw/cli/drama/_design.py
@@ -1,4 +1,4 @@
-"""``design-characters``, ``refresh-urls``, ``design-scenes``, ``assign-voices``, ``design-cover``."""
+"""Drama design commands for visual assets and voices."""
 
 from __future__ import annotations
 
@@ -30,6 +30,14 @@ def drama_design_characters(
     force: Annotated[
         bool, typer.Option("--force", "-f", help="Regenerate existing images.")
     ] = False,
+    image_provider: Annotated[
+        str | None,
+        typer.Option("--image-provider", help="Image provider override: evolink / byteplus."),
+    ] = None,
+    image_model: Annotated[
+        str | None,
+        typer.Option("--image-model", help="Image model override, e.g. gpt-image-2."),
+    ] = None,
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
     """Generate reference images for characters in a drama series."""
@@ -59,14 +67,16 @@ def drama_design_characters(
         Panel(
             f"[bold]Series:[/bold]     {series.title}\n"
             f"[bold]Characters:[/bold] {len(series.characters)}\n"
-            f"[bold]Force:[/bold]      {force}",
+            f"[bold]Force:[/bold]      {force}\n"
+            f"[bold]Provider:[/bold]   {image_provider or 'default'}\n"
+            f"[bold]Model:[/bold]      {image_model or 'default'}",
             title="[bold cyan]Character Design[/bold cyan]",
             border_style="cyan",
         )
     )
 
     try:
-        asyncio.run(_design_characters_async(series, mgr, force))
+        asyncio.run(_design_characters_async(series, mgr, force, image_provider, image_model))
     except Exception as exc:
         out.set_error(str(exc))
         out.emit()
@@ -78,16 +88,28 @@ def drama_design_characters(
             {"name": c.name, "reference_image": c.reference_image}
             for c in series.characters
         ],
+        "image_provider": image_provider,
+        "image_model": image_model,
     })
     out.emit()
 
 
-async def _design_characters_async(series: DramaSeries, mgr: DramaManager, force: bool) -> None:
+async def _design_characters_async(
+    series: DramaSeries,
+    mgr: DramaManager,
+    force: bool,
+    image_provider: str | None,
+    image_model: str | None,
+) -> None:
     console = get_console()
 
     from videoclaw.drama.character_designer import CharacterDesigner
 
-    designer = CharacterDesigner(drama_manager=mgr)
+    designer = CharacterDesigner(
+        drama_manager=mgr,
+        image_provider=image_provider,
+        image_model=image_model,
+    )
 
     with console.status("[cyan]Generating character reference images...", spinner="dots"):
         series = await designer.design_characters(series, force=force)
@@ -214,6 +236,14 @@ def drama_design_scenes(
     force: Annotated[
         bool, typer.Option("--force", "-f", help="Regenerate existing images.")
     ] = False,
+    image_provider: Annotated[
+        str | None,
+        typer.Option("--image-provider", help="Image provider override: evolink / byteplus."),
+    ] = None,
+    image_model: Annotated[
+        str | None,
+        typer.Option("--image-model", help="Image model override, e.g. gpt-image-2."),
+    ] = None,
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
     """Generate reference images for unique scene locations in a drama series."""
@@ -243,29 +273,45 @@ def drama_design_scenes(
         Panel(
             f"[bold]Series:[/bold]   {series.title}\n"
             f"[bold]Episodes:[/bold] {len(series.episodes)}\n"
-            f"[bold]Force:[/bold]    {force}",
+            f"[bold]Force:[/bold]    {force}\n"
+            f"[bold]Provider:[/bold] {image_provider or 'default'}\n"
+            f"[bold]Model:[/bold]    {image_model or 'default'}",
             title="[bold cyan]Scene Design[/bold cyan]",
             border_style="cyan",
         )
     )
 
     try:
-        asyncio.run(_design_scenes_async(series, mgr, force))
+        asyncio.run(_design_scenes_async(series, mgr, force, image_provider, image_model))
     except Exception as exc:
         out.set_error(str(exc))
         out.emit()
         raise typer.Exit(code=1)
 
-    out.set_result({"series_id": series.series_id})
+    out.set_result({
+        "series_id": series.series_id,
+        "image_provider": image_provider,
+        "image_model": image_model,
+    })
     out.emit()
 
 
-async def _design_scenes_async(series: DramaSeries, mgr: DramaManager, force: bool) -> None:
+async def _design_scenes_async(
+    series: DramaSeries,
+    mgr: DramaManager,
+    force: bool,
+    image_provider: str | None,
+    image_model: str | None,
+) -> None:
     console = get_console()
 
     from videoclaw.drama.scene_designer import SceneDesigner
 
-    designer = SceneDesigner(drama_manager=mgr)
+    designer = SceneDesigner(
+        drama_manager=mgr,
+        image_provider=image_provider,
+        image_model=image_model,
+    )
 
     # --- Scene locations ---
     with console.status("[cyan]Generating scene reference images...", spinner="dots"):
@@ -398,6 +444,14 @@ def drama_design_cover(
     force: Annotated[
         bool, typer.Option("--force", "-f", help="Regenerate existing cover.")
     ] = False,
+    image_provider: Annotated[
+        str | None,
+        typer.Option("--image-provider", help="Image provider override: evolink / byteplus."),
+    ] = None,
+    image_model: Annotated[
+        str | None,
+        typer.Option("--image-model", help="Image model override, e.g. gpt-image-2."),
+    ] = None,
     verbose: Annotated[bool, typer.Option("--verbose", "-v")] = False,
 ) -> None:
     """Generate a cover frame (TikTok thumbnail) for an episode."""
@@ -428,14 +482,16 @@ def drama_design_cover(
         Panel(
             f"[bold]Series:[/bold]  {series.title}\n"
             f"[bold]Episode:[/bold] EP{episode:02d} — {ep.title}\n"
-            f"[bold]Force:[/bold]   {force}",
+            f"[bold]Force:[/bold]   {force}\n"
+            f"[bold]Provider:[/bold] {image_provider or 'default'}\n"
+            f"[bold]Model:[/bold]    {image_model or 'default'}",
             title="[bold cyan]Cover Frame Generation[/bold cyan]",
             border_style="cyan",
         )
     )
 
     try:
-        path = asyncio.run(_design_cover_async(series, ep, mgr, force))
+        path = asyncio.run(_design_cover_async(series, ep, mgr, force, image_provider, image_model))
     except Exception as exc:
         out.set_error(str(exc))
         out.emit()
@@ -446,18 +502,29 @@ def drama_design_cover(
         "series_id": series.series_id,
         "episode": episode,
         "cover_frame_path": str(path),
+        "image_provider": image_provider,
+        "image_model": image_model,
     })
     out.emit()
 
 
 async def _design_cover_async(
-    series: DramaSeries, ep: Episode, mgr: DramaManager, force: bool,
+    series: DramaSeries,
+    ep: Episode,
+    mgr: DramaManager,
+    force: bool,
+    image_provider: str | None,
+    image_model: str | None,
 ) -> Path:
     console = get_console()
 
     from videoclaw.drama.cover_frame import CoverFrameGenerator
 
-    gen = CoverFrameGenerator(drama_manager=mgr)
+    gen = CoverFrameGenerator(
+        drama_manager=mgr,
+        image_provider=image_provider,
+        image_model=image_model,
+    )
 
     with console.status("[cyan]Generating cover frame...", spinner="dots"):
         path = await gen.generate_cover(series, ep, force=force)

--- a/src/videoclaw/cli/stage.py
+++ b/src/videoclaw/cli/stage.py
@@ -207,12 +207,20 @@ def image(
         ),
     ],
     provider: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--provider", "-p",
-            help="Image provider: gemini / evolink / byteplus.",
+            help="Image provider: gemini / evolink / byteplus. Defaults to config.",
         ),
-    ] = "gemini",
+    ] = None,
+    model: Annotated[
+        str | None,
+        typer.Option(
+            "--model",
+            "-m",
+            help="Image model id. Defaults to gpt-image-2 for Evolink.",
+        ),
+    ] = None,
     size: Annotated[
         str,
         typer.Option(
@@ -220,6 +228,14 @@ def image(
             help="Image aspect ratio (e.g. 3:4, 1:1, 16:9).",
         ),
     ] = "3:4",
+    resolution: Annotated[
+        str | None,
+        typer.Option("--resolution", help="Image resolution tier for Evolink."),
+    ] = None,
+    quality: Annotated[
+        str | None,
+        typer.Option("--quality", help="Image quality for Evolink: low / medium / high."),
+    ] = None,
     output: Annotated[
         str | None, typer.Option("--output", "-o", help="Output file path.")
     ] = None,
@@ -232,8 +248,8 @@ def image(
     \b
     Examples:
       claw image "a beautiful sunset" -o sunset.png
-      claw image "character portrait" --provider gemini --size 3:4
-      claw image "product photo" --provider evolink -o product.png
+      claw image "character portrait" --provider evolink --model gpt-image-2 --size 3:4
+      claw image "product photo" --provider byteplus --model seedream-5.0-lite -o product.png
     """
     configure_logging(verbose)
     out = get_output()
@@ -243,7 +259,10 @@ def image(
         asyncio.run(_image_async(
             prompt=prompt,
             provider=provider,
+            model=model,
             size=size,
+            resolution=resolution,
+            quality=quality,
             output_path=output,
         ))
     except Exception as exc:
@@ -253,33 +272,60 @@ def image(
 
 
 async def _image_async(
-    *, prompt: str, provider: str, size: str, output_path: str | None,
+    *,
+    prompt: str,
+    provider: str | None,
+    model: str | None,
+    size: str,
+    resolution: str | None,
+    quality: str | None,
+    output_path: str | None,
 ) -> None:
     console = get_console()
     out = get_output()
 
     console.print(f"[cyan]Generating image:[/cyan] {prompt[:80]}")
-    console.print(f"  Provider: {provider}  |  Size: {size}")
+    from videoclaw.config import get_config
+
+    cfg = get_config()
+    effective_provider = (provider or cfg.default_image_provider or "evolink").strip().lower()
+    effective_model = model or _default_image_model_for_provider(
+        effective_provider,
+        config_default=provider is None,
+    )
+    effective_resolution = resolution or cfg.default_image_resolution
+    effective_quality = quality or cfg.default_image_quality
+    console.print(
+        f"  Provider: {effective_provider}  |  Model: {effective_model}  |  Size: {size}"
+        f"  |  Resolution: {effective_resolution}  |  Quality: {effective_quality}"
+    )
 
     with console.status("[cyan]Generating...", spinner="dots"):
-        if provider == "gemini":
+        if effective_provider == "gemini":
             from videoclaw.generation.gemini_image import GeminiImageGenerator
-            gemini_gen = GeminiImageGenerator()
-            image_path = await gemini_gen.generate(prompt=prompt, aspect_ratio=size, output_dir=Path("."))
-        elif provider == "evolink":
+            gemini_gen = GeminiImageGenerator(model=effective_model)
+            image_path = await gemini_gen.generate(prompt=prompt, size=size, output_dir=Path("."))
+        elif effective_provider == "evolink":
             from videoclaw.generation.evolink_image import EvolinkImageGenerator
             evolink_gen = EvolinkImageGenerator()
-            image_path = await evolink_gen.generate(prompt=prompt, aspect_ratio=size, output_dir=Path("."))
-        elif provider == "byteplus":
+            image_path = await evolink_gen.generate(
+                prompt=prompt,
+                model=effective_model,
+                size=size,
+                resolution=effective_resolution,
+                quality=effective_quality,
+                output_dir=Path("."),
+            )
+        elif effective_provider == "byteplus":
             from videoclaw.generation.byteplus_image import BytePlusImageGenerator
-            byteplus_gen = BytePlusImageGenerator()
-            image_path = await byteplus_gen.generate(prompt=prompt, aspect_ratio=size, output_dir=Path("."))
+            byteplus_gen = BytePlusImageGenerator(model=effective_model)
+            image_path = await byteplus_gen.generate(prompt=prompt, size=size, output_dir=Path("."))
         else:
             console.print(
-                f"[red]Unknown provider {provider!r}."
+                f"[red]Unknown provider {effective_provider!r}."
                 " Valid: gemini, evolink, byteplus[/red]"
             )
-            out.set_error(f"Unknown provider: {provider}")
+            out.set_error(f"Unknown provider: {effective_provider}")
             out.emit()
             raise typer.Exit(code=1)
 
@@ -292,14 +338,34 @@ async def _image_async(
         console.print(f"[bold green]Image saved:[/bold green] {image_path}")
         out.set_result({
             "path": str(image_path.resolve()),
-            "provider": provider,
+            "provider": effective_provider,
+            "model": effective_model,
             "size": size,
+            "resolution": effective_resolution,
+            "quality": effective_quality,
         })
     else:
         console.print("[red]Image generation failed.[/red]")
         out.set_error("Image generation failed.")
 
     out.emit()
+
+
+def _default_image_model_for_provider(provider: str, *, config_default: bool = False) -> str:
+    if config_default:
+        from videoclaw.config import get_config
+
+        configured_model = get_config().default_image_model
+        if provider == "evolink" or configured_model != "gpt-image-2":
+            return configured_model
+    if provider == "evolink":
+        return "gpt-image-2"
+    if provider == "byteplus":
+        return "seedream-5.0-lite"
+    if provider == "gemini":
+        from videoclaw.generation.gemini_image import DEFAULT_MODEL
+        return DEFAULT_MODEL
+    return "gpt-image-2"
 
 
 # ---------------------------------------------------------------------------

--- a/src/videoclaw/config.py
+++ b/src/videoclaw/config.py
@@ -42,6 +42,10 @@ def get_config() -> Any:
         # --- Model defaults ---
         default_llm: str = "claude-sonnet-4-6"
         default_video_model: str = "seedance-2.0"
+        default_image_provider: str = "evolink"
+        default_image_model: str = "gpt-image-2"
+        default_image_resolution: str = "1K"
+        default_image_quality: str = "medium"
 
         # --- Language ---
         default_language: str = "zh"

--- a/src/videoclaw/drama/character_designer.py
+++ b/src/videoclaw/drama/character_designer.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
 from videoclaw.drama.models import Character, DramaManager, DramaSeries
+from videoclaw.generation.image_provider import resolve_image_generator
 
 logger = logging.getLogger(__name__)
 
@@ -226,29 +227,24 @@ class CharacterDesigner:
         drama_manager: DramaManager | None = None,
         multi_angle: bool = True,
         turnaround: bool = True,
+        image_provider: str | None = None,
+        image_model: str | None = None,
     ) -> None:
         self._img_gen = image_generator
         self._drama_mgr = drama_manager or DramaManager()
         self._multi_angle = multi_angle
         self._turnaround = turnaround
+        self._image_provider = image_provider
+        self._image_model = image_model
 
     def _ensure_generator(self) -> ImageGenerator:
         if self._img_gen is None:
-            # Default to BytePlus Seedream for character turnaround generation
-            # Verify the API key is actually available before committing to BytePlus
-            try:
-                from videoclaw.config import get_config
-                cfg = get_config()
-                if cfg.byteplus_api_key:
-                    from videoclaw.generation.byteplus_image import BytePlusImageGenerator
-                    self._img_gen = BytePlusImageGenerator()
-                    logger.info("Using BytePlus Seedream for character images")
-                else:
-                    raise ValueError("No BytePlus API key")
-            except (ImportError, ValueError, OSError, RuntimeError):
-                from videoclaw.generation.evolink_image import EvolinkImageGenerator
-                self._img_gen = EvolinkImageGenerator()
-                logger.info("Using Evolink for character images (BytePlus unavailable)")
+            self._img_gen = resolve_image_generator(
+                image_provider=self._image_provider,
+                image_model=self._image_model,
+            )
+            choices = getattr(self._img_gen, "choices", [])
+            logger.info("Using image provider candidates for character images: %s", choices)
         return self._img_gen
 
     async def design_characters(

--- a/src/videoclaw/drama/cover_frame.py
+++ b/src/videoclaw/drama/cover_frame.py
@@ -13,13 +13,12 @@ Cover frame spec:
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from videoclaw.drama.models import DramaManager, DramaSeries
+from videoclaw.generation.image_provider import resolve_image_generator
 
 if TYPE_CHECKING:
     from videoclaw.drama.character_designer import ImageGenerator
@@ -58,24 +57,22 @@ class CoverFrameGenerator:
         self,
         image_generator: ImageGenerator | None = None,
         drama_manager: DramaManager | None = None,
+        image_provider: str | None = None,
+        image_model: str | None = None,
     ) -> None:
         self._img_gen = image_generator
         self._drama_mgr = drama_manager or DramaManager()
+        self._image_provider = image_provider
+        self._image_model = image_model
 
     def _ensure_generator(self) -> ImageGenerator:
-        """Same fallback logic as CharacterDesigner."""
         if self._img_gen is None:
-            try:
-                from videoclaw.config import get_config
-                cfg = get_config()
-                if cfg.byteplus_api_key:
-                    from videoclaw.generation.byteplus_image import BytePlusImageGenerator
-                    self._img_gen = BytePlusImageGenerator()
-                else:
-                    raise ValueError("No BytePlus API key")
-            except (ImportError, ValueError, OSError, RuntimeError):
-                from videoclaw.generation.evolink_image import EvolinkImageGenerator
-                self._img_gen = EvolinkImageGenerator()
+            self._img_gen = resolve_image_generator(
+                image_provider=self._image_provider,
+                image_model=self._image_model,
+            )
+            choices = getattr(self._img_gen, "choices", [])
+            logger.info("Using image provider candidates for cover frames: %s", choices)
         return self._img_gen
 
     async def generate_cover(

--- a/src/videoclaw/drama/scene_designer.py
+++ b/src/videoclaw/drama/scene_designer.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from videoclaw.drama.models import DramaManager, DramaSeries, Episode
+from videoclaw.generation.image_provider import resolve_image_generator
 
 logger = logging.getLogger(__name__)
 
@@ -238,29 +239,22 @@ class SceneDesigner:
         self,
         image_generator: Any | None = None,
         drama_manager: DramaManager | None = None,
+        image_provider: str | None = None,
+        image_model: str | None = None,
     ) -> None:
         self._img_gen = image_generator
         self._drama_mgr = drama_manager or DramaManager()
+        self._image_provider = image_provider
+        self._image_model = image_model
 
     def _ensure_generator(self) -> Any:
         if self._img_gen is None:
-            try:
-                from videoclaw.config import get_config
-                cfg = get_config()
-                if cfg.byteplus_api_key:
-                    from videoclaw.generation.byteplus_image import BytePlusImageGenerator
-                    self._img_gen = BytePlusImageGenerator()
-                    logger.info("Using BytePlus Seedream for scene/prop images")
-                else:
-                    raise ValueError("No BytePlus API key")
-            except (ImportError, ValueError, OSError, RuntimeError) as exc:
-                logger.warning(
-                    "BytePlus unavailable for scene/prop images (%s), falling back to Evolink",
-                    exc,
-                )
-                from videoclaw.generation.evolink_image import EvolinkImageGenerator
-                self._img_gen = EvolinkImageGenerator()
-                logger.info("Using Evolink for scene/prop images (BytePlus unavailable)")
+            self._img_gen = resolve_image_generator(
+                image_provider=self._image_provider,
+                image_model=self._image_model,
+            )
+            choices = getattr(self._img_gen, "choices", [])
+            logger.info("Using image provider candidates for scene/prop images: %s", choices)
         return self._img_gen
 
     async def _generate_image_with_retries(

--- a/src/videoclaw/generation/evolink_image.py
+++ b/src/videoclaw/generation/evolink_image.py
@@ -1,4 +1,4 @@
-"""Image generation via Evolink Seedream 5.0 API.
+"""Image generation via Evolink image API.
 
 Provides an async client that submits image generation tasks, polls for
 completion, downloads results, and returns local file paths.
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class EvolinkImageGenerator(BaseImageGenerator):
-    """Generates images via the Evolink Seedream 5.0 API."""
+    """Generates images via the Evolink image API."""
 
     _poll_interval = 5.0
     _poll_timeout = 180.0
@@ -50,9 +50,10 @@ class EvolinkImageGenerator(BaseImageGenerator):
         *,
         output_dir: Path,
         filename: str = "image.png",
-        model: str = "doubao-seedream-5.0-lite",
+        model: str | None = None,
         size: str = "3:4",
-        quality: str = "2K",
+        resolution: str | None = None,
+        quality: str | None = None,
         reference_urls: list[str] | None = None,
         **kwargs: Any,
     ) -> Path:
@@ -64,24 +65,29 @@ class EvolinkImageGenerator(BaseImageGenerator):
         ----------
         size:
             Ratio format (``"1:1"``, ``"3:4"``, ``"16:9"``, ``"auto"``) or
-            pixel format (``"2048x2048"``).  Seedream 5.0 does NOT accept
-            raw pixel dimensions separated by ``:``.
+            pixel format (``"1024x1024"``).
         """
+        cfg = get_config()
+        model = model or cfg.default_image_model
+        resolution = resolution or cfg.default_image_resolution
+        quality = quality or cfg.default_image_quality
         output_path = self._ensure_dir(output_dir, filename)
 
         body: dict[str, Any] = {
             "model": model,
             "prompt": prompt,
             "size": size,
+            "resolution": resolution,
             "quality": quality,
             "n": 1,
         }
-        if reference_urls:
-            body["image_urls"] = reference_urls
+        image_urls = reference_urls if reference_urls is not None else kwargs.get("image_urls")
+        if image_urls:
+            body["image_urls"] = image_urls
 
         logger.info(
-            "Submitting image generation: model=%s size=%s prompt=%.60s...",
-            model, size, prompt,
+            "Submitting image generation: model=%s size=%s resolution=%s prompt=%.60s...",
+            model, size, resolution, prompt,
         )
 
         async with httpx.AsyncClient(timeout=60.0) as client:

--- a/src/videoclaw/generation/image_provider.py
+++ b/src/videoclaw/generation/image_provider.py
@@ -1,0 +1,162 @@
+"""Small resolver for drama image generator defaults."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from videoclaw.config import get_config
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ImageChoice:
+    provider: str
+    model: str
+
+
+EVOLINK_GPT_IMAGE_2 = ImageChoice(provider="evolink", model="gpt-image-2")
+BYTEPLUS_SEEDREAM_LITE = ImageChoice(
+    provider="byteplus",
+    model="seedream-5.0-lite",
+)
+
+
+def default_image_candidates(explicit: ImageChoice | None = None) -> list[ImageChoice]:
+    """Return provider/model candidates in drama asset preference order."""
+    if explicit is None:
+        return [EVOLINK_GPT_IMAGE_2, BYTEPLUS_SEEDREAM_LITE]
+    if explicit == EVOLINK_GPT_IMAGE_2:
+        return [explicit]
+    return [explicit, EVOLINK_GPT_IMAGE_2]
+
+
+def _configured_candidates(choices: list[ImageChoice], cfg: Any | None = None) -> list[ImageChoice]:
+    """Keep optional fallbacks only when their credentials are configured."""
+    cfg = cfg or get_config()
+    configured: list[ImageChoice] = []
+    explicit_first = choices[0] if choices else None
+
+    for choice in choices:
+        if choice.provider == "byteplus":
+            if choice == explicit_first or getattr(cfg, "byteplus_api_key", None):
+                configured.append(choice)
+            continue
+        if choice.provider == "evolink":
+            if choice == explicit_first or getattr(cfg, "evolink_api_key", None):
+                configured.append(choice)
+            continue
+        if choice == explicit_first:
+            configured.append(choice)
+
+    return configured or choices[:1]
+
+
+class ResolvedImageGenerator:
+    """Image generator that tries explicit candidates in order."""
+
+    def __init__(self, choices: list[ImageChoice]) -> None:
+        if not choices:
+            raise ValueError("At least one image provider candidate is required.")
+        self.choices = choices
+        self.last_image_url: str | None = None
+        self._generators: dict[ImageChoice, Any] = {}
+
+    async def generate(
+        self,
+        prompt: str,
+        *,
+        output_dir: Path,
+        filename: str,
+        **kwargs: Any,
+    ) -> Path:
+        last_error: Exception | None = None
+
+        for choice in self.choices:
+            try:
+                generator = self._generator_for(choice)
+                provider_kwargs = dict(kwargs)
+                provider_kwargs.setdefault("model", choice.model)
+                path = await generator.generate(
+                    prompt,
+                    output_dir=output_dir,
+                    filename=filename,
+                    **provider_kwargs,
+                )
+                self.last_image_url = getattr(generator, "last_image_url", None)
+                return path
+            except Exception as exc:
+                last_error = exc
+                if choice == self.choices[-1]:
+                    break
+                logger.warning(
+                    "Image provider %s:%s failed for %s; trying next candidate: %s",
+                    choice.provider,
+                    choice.model,
+                    filename,
+                    exc,
+                )
+
+        raise last_error or RuntimeError(f"Image generation failed for {filename}")
+
+    def _generator_for(self, choice: ImageChoice) -> Any:
+        if choice not in self._generators:
+            self._generators[choice] = _build_generator(choice)
+        return self._generators[choice]
+
+
+def resolve_image_generator(
+    *,
+    image_provider: str | None = None,
+    image_model: str | None = None,
+) -> ResolvedImageGenerator:
+    cfg = get_config()
+    explicit = _explicit_choice(image_provider=image_provider, image_model=image_model)
+    if explicit is None:
+        explicit = _config_default_choice(cfg)
+    choices = _configured_candidates(default_image_candidates(explicit), cfg)
+    return ResolvedImageGenerator(choices)
+
+
+def _config_default_choice(cfg: Any) -> ImageChoice | None:
+    provider = getattr(cfg, "default_image_provider", None)
+    model = getattr(cfg, "default_image_model", None)
+    if provider == "byteplus" and model == EVOLINK_GPT_IMAGE_2.model:
+        model = None
+    choice = _explicit_choice(image_provider=provider, image_model=model)
+    if choice == EVOLINK_GPT_IMAGE_2:
+        return None
+    return choice
+
+
+def _explicit_choice(
+    *,
+    image_provider: str | None,
+    image_model: str | None,
+) -> ImageChoice | None:
+    if not image_provider and not image_model:
+        return None
+
+    provider = (image_provider or "evolink").strip().lower()
+    if provider == "evolink":
+        model = image_model or EVOLINK_GPT_IMAGE_2.model
+    elif provider == "byteplus":
+        model = image_model or BYTEPLUS_SEEDREAM_LITE.model
+    else:
+        model = image_model or ""
+    return ImageChoice(provider=provider, model=model)
+
+
+def _build_generator(choice: ImageChoice) -> Any:
+    if choice.provider == "evolink":
+        from videoclaw.generation.evolink_image import EvolinkImageGenerator
+
+        return EvolinkImageGenerator()
+    if choice.provider == "byteplus":
+        from videoclaw.generation.byteplus_image import BytePlusImageGenerator
+
+        return BytePlusImageGenerator(model=choice.model)
+    raise ValueError(f"Unsupported image provider: {choice.provider}")

--- a/tests/test_cli_image_defaults.py
+++ b/tests/test_cli_image_defaults.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+from videoclaw.cli import app
+from videoclaw.cli._output import get_output
+from videoclaw.generation import byteplus_image, evolink_image, gemini_image
+from videoclaw.generation.gemini_image import DEFAULT_MODEL as GEMINI_DEFAULT_MODEL
+
+
+def _reset_output() -> None:
+    out = get_output()
+    out.json_mode = False
+    out._command = ""
+    out._result = None
+    out._error = None
+    out._exit_code = 0
+
+
+def _json_envelope(stdout: str) -> dict[str, Any]:
+    return json.loads(stdout.strip().splitlines()[-1])
+
+
+def test_image_help_exposes_provider_model_resolution_and_quality_options() -> None:
+    _reset_output()
+
+    result = CliRunner().invoke(app, ["image", "--help"])
+
+    assert result.exit_code == 0
+    assert "--provider" in result.stdout
+    assert "--model" in result.stdout
+    assert "--resolution" in result.stdout
+    assert "--quality" in result.stdout
+
+
+def test_drama_design_commands_expose_image_provider_overrides() -> None:
+    _reset_output()
+
+    runner = CliRunner()
+    for command in ("design-characters", "design-scenes", "design-cover"):
+        result = runner.invoke(app, ["drama", command, "--help"])
+
+        assert result.exit_code == 0
+        assert "--image-provider" in result.stdout
+        assert "--image-model" in result.stdout
+
+
+def test_image_defaults_to_evolink_gpt_image_2_1k_medium(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+    generated = tmp_path / "generated.png"
+
+    class FakeEvolinkImageGenerator:
+        def __init__(self) -> None:
+            calls.append({"provider": "evolink-init"})
+
+        async def generate(self, **kwargs: Any) -> Path:
+            calls.append({"provider": "evolink-generate", **kwargs})
+            generated.write_bytes(b"png")
+            return generated
+
+    class FakeGeminiImageGenerator:
+        async def generate(self, **kwargs: Any) -> Path:
+            raise AssertionError("default image provider should not be gemini")
+
+    monkeypatch.setattr(evolink_image, "EvolinkImageGenerator", FakeEvolinkImageGenerator)
+    monkeypatch.setattr(gemini_image, "GeminiImageGenerator", FakeGeminiImageGenerator)
+
+    _reset_output()
+    output = tmp_path / "out.png"
+    result = CliRunner().invoke(
+        app,
+        ["--json", "image", "cinematic portrait", "--output", str(output)],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert calls[-1]["prompt"] == "cinematic portrait"
+    assert calls[-1]["model"] == "gpt-image-2"
+    assert calls[-1]["size"] == "3:4"
+    assert calls[-1]["resolution"] == "1K"
+    assert calls[-1]["quality"] == "medium"
+
+    envelope = _json_envelope(result.stdout)
+    assert envelope["ok"] is True
+    assert envelope["data"]["provider"] == "evolink"
+    assert envelope["data"]["model"] == "gpt-image-2"
+    assert envelope["data"]["resolution"] == "1K"
+    assert envelope["data"]["quality"] == "medium"
+
+
+def test_image_keeps_byteplus_model_override_compatibility(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+    generated = tmp_path / "byteplus.png"
+
+    class FakeBytePlusImageGenerator:
+        def __init__(self, *, model: str) -> None:
+            calls.append({"provider": "byteplus-init", "model": model})
+
+        async def generate(self, **kwargs: Any) -> Path:
+            calls.append({"provider": "byteplus-generate", **kwargs})
+            generated.write_bytes(b"png")
+            return generated
+
+    monkeypatch.setattr(byteplus_image, "BytePlusImageGenerator", FakeBytePlusImageGenerator)
+
+    _reset_output()
+    output = tmp_path / "out.png"
+    result = CliRunner().invoke(
+        app,
+        [
+            "--json",
+            "image",
+            "scene concept",
+            "--provider",
+            "byteplus",
+            "--model",
+            "seedream-5.0-lite",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert calls[0] == {"provider": "byteplus-init", "model": "seedream-5.0-lite"}
+    assert calls[-1]["prompt"] == "scene concept"
+    assert calls[-1]["size"] == "3:4"
+
+    envelope = _json_envelope(result.stdout)
+    assert envelope["ok"] is True
+    assert envelope["data"]["provider"] == "byteplus"
+    assert envelope["data"]["model"] == "seedream-5.0-lite"
+
+
+def test_image_keeps_gemini_provider_default_model_compatibility(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+    generated = tmp_path / "gemini.png"
+
+    class FakeGeminiImageGenerator:
+        def __init__(self, *, model: str = GEMINI_DEFAULT_MODEL) -> None:
+            calls.append({"provider": "gemini-init", "model": model})
+
+        async def generate(self, **kwargs: Any) -> Path:
+            calls.append({"provider": "gemini-generate", **kwargs})
+            generated.write_bytes(b"png")
+            return generated
+
+    monkeypatch.setattr(gemini_image, "GeminiImageGenerator", FakeGeminiImageGenerator)
+
+    _reset_output()
+    output = tmp_path / "out.png"
+    result = CliRunner().invoke(
+        app,
+        [
+            "--json",
+            "image",
+            "legacy image",
+            "--provider",
+            "gemini",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert calls[0] == {"provider": "gemini-init", "model": GEMINI_DEFAULT_MODEL}
+    assert calls[-1]["prompt"] == "legacy image"
+    assert calls[-1]["size"] == "3:4"
+
+    envelope = _json_envelope(result.stdout)
+    assert envelope["ok"] is True
+    assert envelope["data"]["provider"] == "gemini"
+    assert envelope["data"]["model"] == GEMINI_DEFAULT_MODEL

--- a/tests/test_cover_frame.py
+++ b/tests/test_cover_frame.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from videoclaw.drama.cover_frame import CoverFrameGenerator, COVER_FRAME_PROMPT
+from videoclaw.drama.cover_frame import COVER_FRAME_PROMPT, CoverFrameGenerator
 from videoclaw.drama.models import Character, DramaScene, DramaSeries, Episode, ShotScale
 
 
@@ -69,6 +68,28 @@ class TestCoverFrameGenerator:
     def test_build_prompt_3_4_aspect(self):
         """The prompt template specifies 3:4 portrait."""
         assert "3:4" in COVER_FRAME_PROMPT
+
+    def test_without_injected_generator_uses_image_provider_resolver(self, monkeypatch):
+        resolved = MagicMock()
+        resolver = MagicMock(return_value=resolved)
+        fallback = MagicMock()
+
+        monkeypatch.setattr(
+            "videoclaw.drama.cover_frame.resolve_image_generator",
+            resolver,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "videoclaw.config.get_config",
+            lambda: MagicMock(byteplus_api_key=None, evolink_api_key="evolink-key"),
+        )
+        monkeypatch.setattr(
+            "videoclaw.generation.evolink_image.EvolinkImageGenerator",
+            lambda: fallback,
+        )
+
+        assert CoverFrameGenerator()._ensure_generator() is resolved
+        resolver.assert_called_once_with(image_provider=None, image_model=None)
 
     @pytest.mark.asyncio
     async def test_generate_cover_calls_generator(self, tmp_path):

--- a/tests/test_evolink_gpt_image2.py
+++ b/tests/test_evolink_gpt_image2.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from videoclaw.config import get_config
+from videoclaw.generation import evolink_image
+from videoclaw.generation.evolink_image import EvolinkImageGenerator
+
+
+def test_config_exposes_evolink_gpt_image2_defaults(monkeypatch):
+    monkeypatch.delenv("VIDEOCLAW_DEFAULT_IMAGE_PROVIDER", raising=False)
+    monkeypatch.delenv("VIDEOCLAW_DEFAULT_IMAGE_MODEL", raising=False)
+    monkeypatch.delenv("VIDEOCLAW_DEFAULT_IMAGE_RESOLUTION", raising=False)
+    monkeypatch.delenv("VIDEOCLAW_DEFAULT_IMAGE_QUALITY", raising=False)
+    get_config.cache_clear()
+
+    try:
+        cfg = get_config()
+
+        assert cfg.default_image_provider == "evolink"
+        assert cfg.default_image_model == "gpt-image-2"
+        assert cfg.default_image_resolution == "1K"
+        assert cfg.default_image_quality == "medium"
+    finally:
+        get_config.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_evolink_gpt_image2_payload_polls_and_downloads(
+    tmp_path: Path,
+    monkeypatch,
+):
+    calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    class FakeResponse:
+        def __init__(
+            self,
+            *,
+            status_code: int = 200,
+            json_data: dict[str, Any] | None = None,
+            content: bytes = b"",
+        ) -> None:
+            self.status_code = status_code
+            self._json_data = json_data or {}
+            self.content = content
+            self.text = str(self._json_data)
+
+        def json(self) -> dict[str, Any]:
+            return self._json_data
+
+        def raise_for_status(self) -> None:
+            if self.status_code >= 400:
+                raise AssertionError(f"unexpected status {self.status_code}")
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            json: dict[str, Any],
+        ) -> FakeResponse:
+            calls.append(("POST", url, json))
+            return FakeResponse(json_data={"task_id": "task-123"})
+
+        async def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str] | None = None,
+            timeout: float | None = None,
+        ) -> FakeResponse:
+            calls.append(("GET", url, None))
+            if url.endswith("/tasks/task-123"):
+                return FakeResponse(
+                    json_data={
+                        "status": "completed",
+                        "results": ["https://cdn.example.com/result.png"],
+                    }
+                )
+            if url == "https://cdn.example.com/result.png":
+                return FakeResponse(content=b"png-bytes")
+            raise AssertionError(f"unexpected GET {url}")
+
+    monkeypatch.setattr(evolink_image.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(EvolinkImageGenerator, "_poll_interval", 0.0)
+
+    generator = EvolinkImageGenerator(
+        api_key="test-key",
+        api_base="https://api.evolink.test/v1",
+    )
+
+    output_path = await generator.generate(
+        "cinematic character sheet",
+        output_dir=tmp_path,
+        reference_urls=["https://cdn.example.com/ref.png"],
+    )
+
+    assert output_path == tmp_path / "image.png"
+    assert output_path.read_bytes() == b"png-bytes"
+    assert generator.last_image_url == "https://cdn.example.com/result.png"
+
+    assert calls[0] == (
+        "POST",
+        "https://api.evolink.test/v1/images/generations",
+        {
+            "model": "gpt-image-2",
+            "prompt": "cinematic character sheet",
+            "size": "3:4",
+            "resolution": "1K",
+            "quality": "medium",
+            "n": 1,
+            "image_urls": ["https://cdn.example.com/ref.png"],
+        },
+    )
+    assert calls[1] == ("GET", "https://api.evolink.test/v1/tasks/task-123", None)
+    assert calls[2] == ("GET", "https://cdn.example.com/result.png", None)
+
+
+@pytest.mark.asyncio
+async def test_evolink_gpt_image2_accepts_image_urls_alias(
+    tmp_path: Path,
+    monkeypatch,
+):
+    payloads: list[dict[str, Any]] = []
+
+    class FakeResponse:
+        status_code = 200
+        content = b"png-bytes"
+        text = "{}"
+
+        def __init__(self, json_data: dict[str, Any] | None = None) -> None:
+            self._json_data = json_data or {}
+
+        def json(self) -> dict[str, Any]:
+            return self._json_data
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            pass
+
+        async def __aenter__(self) -> FakeAsyncClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def post(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str],
+            json: dict[str, Any],
+        ) -> FakeResponse:
+            payloads.append(json)
+            return FakeResponse(json_data={"data": [{"url": "https://cdn.example.com/result.png"}]})
+
+        async def get(
+            self,
+            url: str,
+            *,
+            headers: dict[str, str] | None = None,
+            timeout: float | None = None,
+        ) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(evolink_image.httpx, "AsyncClient", FakeAsyncClient)
+
+    generator = EvolinkImageGenerator(
+        api_key="test-key",
+        api_base="https://api.evolink.test/v1",
+    )
+
+    await generator.generate(
+        "edit this reference",
+        output_dir=tmp_path,
+        image_urls=["https://cdn.example.com/ref.png"],
+    )
+
+    assert payloads[0]["image_urls"] == ["https://cdn.example.com/ref.png"]

--- a/tests/test_image_provider_resolution.py
+++ b/tests/test_image_provider_resolution.py
@@ -1,0 +1,230 @@
+"""Tests for drama image provider resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from videoclaw.drama.character_designer import CharacterDesigner
+from videoclaw.drama.scene_designer import SceneDesigner
+from videoclaw.generation import image_provider as image_provider_module
+from videoclaw.generation.image_provider import (
+    ImageChoice,
+    default_image_candidates,
+    resolve_image_generator,
+)
+
+
+def test_default_candidates_prefer_evolink_gpt_image_2_before_byteplus() -> None:
+    choices = default_image_candidates()
+
+    assert choices == [
+        ImageChoice(provider="evolink", model="gpt-image-2"),
+        ImageChoice(provider="byteplus", model="seedream-5.0-lite"),
+    ]
+
+
+def test_explicit_byteplus_tries_byteplus_then_evolink_fallback() -> None:
+    choices = default_image_candidates(
+        ImageChoice(provider="byteplus", model="seedream-5.0-lite")
+    )
+
+    assert choices == [
+        ImageChoice(provider="byteplus", model="seedream-5.0-lite"),
+        ImageChoice(provider="evolink", model="gpt-image-2"),
+    ]
+
+
+def test_explicit_evolink_gpt_image_2_has_no_silent_fallback() -> None:
+    choices = default_image_candidates(
+        ImageChoice(provider="evolink", model="gpt-image-2")
+    )
+
+    assert choices == [ImageChoice(provider="evolink", model="gpt-image-2")]
+
+
+def test_resolver_keeps_byteplus_optional_when_no_byteplus_key(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "videoclaw.generation.image_provider.get_config",
+        lambda: SimpleNamespace(
+            evolink_api_key="evolink-key",
+            byteplus_api_key=None,
+        ),
+    )
+
+    generator = resolve_image_generator()
+
+    assert generator.choices == [ImageChoice(provider="evolink", model="gpt-image-2")]
+
+
+def test_resolver_includes_byteplus_fallback_when_configured(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "videoclaw.generation.image_provider.get_config",
+        lambda: SimpleNamespace(
+            evolink_api_key="evolink-key",
+            byteplus_api_key="byteplus-key",
+        ),
+    )
+
+    generator = resolve_image_generator()
+
+    assert generator.choices == [
+        ImageChoice(provider="evolink", model="gpt-image-2"),
+        ImageChoice(provider="byteplus", model="seedream-5.0-lite"),
+    ]
+
+
+def test_resolver_honors_configured_default_provider_before_evolink(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "videoclaw.generation.image_provider.get_config",
+        lambda: SimpleNamespace(
+            evolink_api_key="evolink-key",
+            byteplus_api_key="byteplus-key",
+            default_image_provider="byteplus",
+            default_image_model="seedream-5.0-lite",
+        ),
+    )
+
+    generator = resolve_image_generator()
+
+    assert generator.choices == [
+        ImageChoice(provider="byteplus", model="seedream-5.0-lite"),
+        ImageChoice(provider="evolink", model="gpt-image-2"),
+    ]
+
+
+def test_resolver_uses_provider_default_when_only_provider_is_configured(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "videoclaw.generation.image_provider.get_config",
+        lambda: SimpleNamespace(
+            evolink_api_key="evolink-key",
+            byteplus_api_key="byteplus-key",
+            default_image_provider="byteplus",
+            default_image_model="gpt-image-2",
+        ),
+    )
+
+    generator = resolve_image_generator()
+
+    assert generator.choices[0] == ImageChoice(
+        provider="byteplus",
+        model="seedream-5.0-lite",
+    )
+
+
+def test_character_designer_without_injected_generator_uses_resolver(monkeypatch) -> None:
+    resolved = MagicMock()
+
+    monkeypatch.setattr(
+        "videoclaw.drama.character_designer.resolve_image_generator",
+        lambda **kwargs: resolved,
+    )
+
+    designer = CharacterDesigner(image_provider="byteplus", image_model="seedream-5.0-lite")
+
+    assert designer._ensure_generator() is resolved
+
+
+def test_scene_designer_without_injected_generator_uses_resolver(monkeypatch) -> None:
+    resolved = MagicMock()
+
+    monkeypatch.setattr(
+        "videoclaw.drama.scene_designer.resolve_image_generator",
+        lambda **kwargs: resolved,
+    )
+
+    designer = SceneDesigner(image_provider="byteplus", image_model="seedream-5.0-lite")
+
+    assert designer._ensure_generator() is resolved
+
+
+def test_injected_generators_are_preserved() -> None:
+    injected = MagicMock()
+
+    assert CharacterDesigner(image_generator=injected)._ensure_generator() is injected
+    assert SceneDesigner(image_generator=injected)._ensure_generator() is injected
+
+
+@pytest.mark.asyncio
+async def test_explicit_byteplus_generation_falls_back_to_evolink(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    output_path = tmp_path / "image.png"
+    output_path.write_bytes(b"image")
+    byteplus = MagicMock()
+    byteplus.generate = AsyncMock(side_effect=RuntimeError("byteplus failed"))
+    evolink = MagicMock()
+    evolink.last_image_url = "https://example.com/image.png"
+    evolink.generate = AsyncMock(return_value=output_path)
+
+    monkeypatch.setattr(
+        "videoclaw.generation.image_provider.get_config",
+        lambda: SimpleNamespace(
+            evolink_api_key="evolink-key",
+            byteplus_api_key="byteplus-key",
+        ),
+    )
+    monkeypatch.setattr(
+        image_provider_module,
+        "_build_generator",
+        lambda choice: byteplus if choice.provider == "byteplus" else evolink,
+    )
+
+    generator = resolve_image_generator(
+        image_provider="byteplus",
+        image_model="seedream-5.0-lite",
+    )
+
+    result = await generator.generate(
+        "prompt",
+        output_dir=tmp_path,
+        filename="image.png",
+        size="3:4",
+    )
+
+    assert result == output_path
+    byteplus.generate.assert_awaited_once()
+    evolink.generate.assert_awaited_once()
+    assert evolink.generate.await_args.kwargs["model"] == "gpt-image-2"
+    assert generator.last_image_url == "https://example.com/image.png"
+
+
+@pytest.mark.asyncio
+async def test_explicit_evolink_generation_failure_does_not_fallback(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    evolink = MagicMock()
+    evolink.generate = AsyncMock(side_effect=RuntimeError("evolink failed"))
+
+    monkeypatch.setattr(
+        "videoclaw.generation.image_provider.get_config",
+        lambda: SimpleNamespace(
+            evolink_api_key="evolink-key",
+            byteplus_api_key="byteplus-key",
+        ),
+    )
+    monkeypatch.setattr(
+        image_provider_module,
+        "_build_generator",
+        lambda choice: evolink,
+    )
+
+    generator = resolve_image_generator(
+        image_provider="evolink",
+        image_model="gpt-image-2",
+    )
+
+    with pytest.raises(RuntimeError, match="evolink failed"):
+        await generator.generate(
+            "prompt",
+            output_dir=tmp_path,
+            filename="image.png",
+        )
+
+    assert generator.choices == [ImageChoice(provider="evolink", model="gpt-image-2")]
+    evolink.generate.assert_awaited_once()

--- a/uv.lock
+++ b/uv.lock
@@ -2232,13 +2232,15 @@ wheels = [
 
 [[package]]
 name = "videoclaw"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "edge-tts" },
     { name = "httpx" },
     { name = "litellm" },
+    { name = "numpy" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyyaml" },
@@ -2283,6 +2285,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "litellm", specifier = ">=1.55.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.14.0" },
+    { name = "numpy", specifier = ">=2.0.0" },
+    { name = "pillow", specifier = ">=12.0.0" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },


### PR DESCRIPTION
## Summary

- Default image asset generation now uses Evolink `gpt-image-2` with `resolution=1K` and `quality=medium`.
- Added a shared drama image-provider resolver with Evolink-first fallback behavior and optional BytePlus `seedream-5.0-lite` support.
- Added `claw image` model/resolution/quality controls and `--image-provider` / `--image-model` overrides for drama design commands.
- Bumped release metadata, skills, install docs, manifest, and package version to `0.1.3`; added required runtime deps for packaged CLI image/frame analysis.

## Verification

- `uv run ruff check src/videoclaw/generation/image_provider.py tests/test_image_provider_resolution.py`
- `uv run pytest tests/test_image_provider_resolution.py -q`
- `uv run pytest tests/ -q` -> `1012 passed`
- `uv run python packaging/skills-validate.py skills/` -> valid, version `0.1.3`
- `uv run python packaging/manifest-validate.py packaging/agent-cli.yaml` -> valid
- `./agent-cli-release-gate.sh package --skip-setup` -> passed; rebuilt `dist/videoclaw-0.1.3-py3-none-any.whl`, PyInstaller `dist/claw`, and verified packaged `claw setup` via both `python-fallback` and `npx-skills` installers.

## Notes

Real LLM/video E2E stages were not run; the package gate skipped those billable checks because `--with-real-llm` / `--with-real-video` were not requested.